### PR TITLE
Better 2019.2 Build Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'kotlin'
 
 group 'io.acari'
-version '1.4.0'
+version '1.4.1'
 
 repositories {
     mavenCentral()

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -1,5 +1,11 @@
 <h1>Changelog</h1>
-<hr/><h1>1.4.0</h1>
+<hr/><h1>1.4.1</h1>
+<ul>
+  <li>Better 2019.2 build support!
+  <ul>
+    <li>Fixes the issue with configurations not being persisted.</li>
+  </ul></li>
+</ul><h1>1.4.0</h1>
 <ul>
   <li>Rainbow Mode!
   <ul>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ---- 
 
+# 1.4.1
+
+- Better 2019.2 build support!
+    - Fixes the issue with configurations not being persisted.  
+
 # 1.4.0
 
 - Rainbow Mode!

--- a/src/main/kotlin/io/acari/n7/icon/NormandyColorPatcher.kt
+++ b/src/main/kotlin/io/acari/n7/icon/NormandyColorPatcher.kt
@@ -25,7 +25,7 @@ class NormandyColorPatcher(private val otherColorPatcher: (Element) ->Unit = {} 
     }
 
     val themedSecondaryAttribute = svg.getAttribute("themedSecondary")
-    if(ThemeConfiguration.isRainbowMode){
+    if(themedSecondaryAttribute.isNotBlank() && ThemeConfiguration.isRainbowMode){
       when(themedSecondaryAttribute){
         "fill"-> svg.setAttribute("fill", NormandyTheme.secondaryColorString())
         "stroke"-> svg.setAttribute("stroke", NormandyTheme.secondaryColorString())

--- a/src/main/kotlin/io/acari/n7/notification/UpdateComponent.kt
+++ b/src/main/kotlin/io/acari/n7/notification/UpdateComponent.kt
@@ -5,12 +5,12 @@ import com.intellij.openapi.project.Project
 
 import io.acari.n7.config.ConfigurationPersistence
 
-const val VERSION = "v1.4.0"
+const val VERSION = "v1.4.1"
 val UPDATE_MESSAGE =
     """
       What's New?<br>
       <ul>
-      <li>Rainbow Mode!</li>
+      <li>Better 2019.2 build support!</li>
       <br>
       Thanks again for downloading <b>Normandy Progress Bar UI</b>! •‿•<br>
           <br>See <a href="https://github.com/cyclic-reference/normandy-progress-bar/blob/master/docs/CHANGELOG.md">Changelog</a> for more details.


### PR DESCRIPTION
Fixes the issue with the configurations not saving. Causing the update window to show and the plugin not remembering what configurations you saved.