### PR TITLE
Form Fix 2020.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'kotlin'
 
 group 'io.acari'
-version '1.8.0'
+version '1.8.1'
 
 repositories {
     mavenCentral()

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -1,5 +1,13 @@
 <h1 id="changelog">Changelog</h1>
 <hr>
+<h1 id="1-8-1">1.8.1</h1>
+<ul>
+<li>Fixed settings not showing up in 2020.1 EAP builds.<ul>
+<li>Thanks for reporting the issue!</li>
+</ul>
+</li>
+</ul>
+
 <h1 id="1-8-0">1.8.0</h1>
 <ul>
     <li>2020.1 Build Support</li>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ---- 
 
+# 1.8.1
+
+- Fixed settings not showing up in 2020.1 EAP builds.
+  - Thanks for reporting the issue!
+
 # 1.8.0
 
 - 2020.1 Build Support

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 #Pringle
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-1/183.5429.30
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-1/191.6014.8
+#idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/CLion/ch-0/201.4865.10
 
 #Sandwich
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/183.5429.30

--- a/src/main/kotlin/io/acari/n7/notification/UpdateComponent.kt
+++ b/src/main/kotlin/io/acari/n7/notification/UpdateComponent.kt
@@ -5,12 +5,13 @@ import com.intellij.openapi.project.Project
 
 import io.acari.n7.config.ConfigurationPersistence
 
-const val VERSION = "v1.8.0"
+const val VERSION = "v1.8.1"
 val UPDATE_MESSAGE =
     """
       What's New?<br>
       <ul>
-      <li>2020.1 Build Support</li>
+      <li>Fixed settings in 2020.1-EAP.
+            <ul><li>Thanks for reporting the issue!</li></ul></li>
       <br>
       Thanks again for downloading <b>Normandy Progress Bar UI</b>! •‿•<br>
           <br>See <a href="https://github.com/cyclic-reference/normandy-progress-bar/blob/master/docs/CHANGELOG.md">Changelog</a> for more details.


### PR DESCRIPTION
Fixed issue with the form not coming up in the 2020.1 eap builds.

Just had to re-build the plugin with the 2020.1 SDK, because the Kotlin DSL has breaking changes.